### PR TITLE
make path.join results consistent

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const ABSOLUTE_PATTERN = /^(\s*)\/([^'"`]*)/g;
 const VUE_PATTER = /^\s*(@)\/([^'"`]*)/g;
 
 const replace = (baseURI, dirname = '', dotsReplacement = undefined) =>
-  (match, dots, rest) => `${baseURI}${path.join(dirname, dotsReplacement === undefined ? dots : dotsReplacement, rest)}`;
+  (match, dots, rest) => `${baseURI}${path.posix.join(dirname, dotsReplacement === undefined ? dots : dotsReplacement, rest)}`;
 
 module.exports = function ({ types: t }) {
   return {


### PR DESCRIPTION
The `path` module behaves differently on different platforms, so this plugin currently does not work on Windows. This pull request proposes to make `path.join` results consistent.